### PR TITLE
fix: Enable directives in result schema

### DIFF
--- a/server/src/graphql.ts
+++ b/server/src/graphql.ts
@@ -19,7 +19,7 @@ export const createApolloServer = async function (app: Express, config: Config) 
     const pubSub = getPubSub();
 
     const typeDefs = loadSchemaFiles(join(__dirname, '/schema/')).join('\n');
-    const schema = buildSchema(typeDefs);
+    const schema = buildSchema(typeDefs, { assumeValid: true });
     const context = createOffixMongoCRUDRuntimeContext(models, schema, db, pubSub);
 
     let apolloConfig = {
@@ -28,7 +28,6 @@ export const createApolloServer = async function (app: Express, config: Config) 
         playground: true,
         context: context
     }
-
 
     apolloConfig = buildKeycloakApolloConfig(app, apolloConfig)
 


### PR DESCRIPTION
Disable validation for schema so we can load it with directives that are not supplied. There are follow up issues that I will need to resolve later:

- Add error code to keycloak lib
- Show actual dialog to user that error happened

## Verification

Follow the local walkthought for keycloak (add hasRole)